### PR TITLE
Update @angular/flex-layout to > v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/common": "^5.0.3",
     "@angular/compiler": "^5.0.3",
     "@angular/core": "^5.0.3",
-    "@angular/flex-layout": "^2.0.0-beta.10-4905443",
+    "@angular/flex-layout": "^5.0.0-beta.13",
     "@angular/forms": "^5.0.3",
     "@angular/http": "^5.0.3",
     "@angular/material": "^5.0.0-rc.2",


### PR DESCRIPTION
@angular/flex-layout  ^2.0.0-beta.10-4905443 throws errors on npm install/start/ls with Angular v5